### PR TITLE
configure-gadgets: Use udevadm settle to wait for USB devices

### DIFF
--- a/board/raspberrypi64-mass-storage-gadget/rootfs_overlay/usr/local/bin/configure-gadgets
+++ b/board/raspberrypi64-mass-storage-gadget/rootfs_overlay/usr/local/bin/configure-gadgets
@@ -18,12 +18,29 @@ if grep -q 2837 /proc/device-tree/compatible; then
    sleep 1
 fi
 
-if lspci | grep -iq "USB Controller"; then
-   # For slow to init drives it might be better to use udev events
-   # However, that's unecessary complexity for a rare use-case
-   # right now.
-   echo "Detected USB Controller - delaying for drive init"
+if ls /sys/bus/usb/devices/usb* > /dev/null 2>&1; then
+   echo "Detected USB Controller - waiting for drive enumeration"
    sleep 5
+   udevadm settle --timeout=30
+fi
+
+# Wait until at least one storage device has appeared.  If enumeration was
+# slow or a device was plugged in slightly late this loop catches it.  After
+# the timeout we proceed anyway so that the ACM serial console becomes
+# available for debugging.
+MSD_TIMEOUT=30
+count=0
+while [ ${count} -lt ${MSD_TIMEOUT} ]; do
+   for dev in mmcblk0 nvme0n1 sda sdb sdc sdd; do
+      [ -e /dev/${dev} ] && break 2
+   done
+   echo "Waiting for storage device... (${count}s)"
+   count=$((count + 1))
+   sleep 1
+done
+
+if [ ${count} -lt ${MSD_TIMEOUT} ]; then
+   echo "Storage device found after ${count}s"
 fi
 
 mkdir -p "${CONFIGFS}"
@@ -60,6 +77,9 @@ for dev in mmcblk0 nvme0n1 sda sdb sdc sdd; do
 done
 mkdir -p functions/acm.usb0
 ln -s functions/acm.usb0 configs/c.1/
+if [ ${id} -eq 0 ]; then
+   echo "No storage devices found, proceeding with ACM only"
+fi
 
 count=0
 while [ ${count} -lt 15 ]; do


### PR DESCRIPTION
The 'sleep' sometimes misses USB devices coming up late. I haven't done a lot of testing with a variety of devices, but udevadm settle seems to work for me reliably. It would be good to test with a slow spin-up HDD just to be sure it works as intended.